### PR TITLE
Added custom reload interval feature

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,21 +3,20 @@ chrome.browserAction.setBadgeBackgroundColor({color: '#4688F1'});
 let reloads_holder = {};
 
 chrome.storage.onChanged.addListener((whatchanged, area) => {
-    if(area==="local"){
-        let keys = Object.keys(whatchanged);
-        keys.forEach(element => {
-            console.log(whatchanged[element]);
-            if(whatchanged[element].newValue){
-                reloads_holder[element] = setInterval(()=>{
-                    chrome.tabs.reload(parseInt(element));
-                }, 10000);
-            }
-            else {
-                clearInterval(reloads_holder[element]);
+    const currentKey = Object.keys(whatchanged)[0];
+    const currentVal = whatchanged[currentKey].newValue;
+    if(area === "local" && typeof currentVal === 'boolean' ) {
+        chrome.storage.local.get('input', (result) => {
+            if (currentVal) {
+                // Start reloading current tab
+                reloads_holder[currentKey] = setInterval(()=>{
+                    chrome.tabs.reload(parseInt(currentKey));
+                }, result.input * 1000);
+            } else {
+                // Stop reloading
+                clearInterval(reloads_holder[currentKey]);
             }
         });
-
-        
     }
 });
 
@@ -25,11 +24,10 @@ chrome.tabs.onActivated.addListener(()=>{
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
         let tab = tabs[0];
         chrome.storage.local.get(tab.id.toString(), (items) => {
-            if(items[tab.id]){
-                chrome.browserAction.setBadgeText({text: 'ON'});
-            }
-            else {
-                chrome.browserAction.setBadgeText({text: 'OFF'});
+            if (items[tab.id]) {
+                chrome.browserAction.setBadgeText({ text: 'ON' });
+            } else {
+                chrome.browserAction.setBadgeText({ text: 'OFF' });
             }
         });
       });

--- a/background.js
+++ b/background.js
@@ -9,9 +9,11 @@ chrome.storage.onChanged.addListener((whatchanged, area) => {
         chrome.storage.local.get('input', (result) => {
             if (currentVal) {
                 // Start reloading current tab
+                const reloadInterval = result.input ? result.input * 1000 : 10000;
+
                 reloads_holder[currentKey] = setInterval(()=>{
                     chrome.tabs.reload(parseInt(currentKey));
-                }, result.input * 1000);
+                }, reloadInterval);
             } else {
                 // Stop reloading
                 clearInterval(reloads_holder[currentKey]);

--- a/popup.html
+++ b/popup.html
@@ -5,7 +5,9 @@
       </style>
     </head>
     <body>
-      <input type="checkbox" id="active"/> Activate timer
+      <label for="reload-int-input">Refresh interval (seconds)</label>
+      <input type="number" min='1' id="reload-int-input" />
+      <input type="checkbox" id="active"/> Activate Auto-reload
       <script src="popup.js"></script>
     </body>
   </html>

--- a/popup.js
+++ b/popup.js
@@ -1,38 +1,46 @@
 let active = document.getElementById('active');
+const reloadInput = document.getElementById('reload-int-input');
 
+// Maintain checked input box if this window has active reload
 chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
   let tab = tabs[0];
   chrome.storage.local.get(tab.id.toString(), (items) => {
       if(items[tab.id]){
           console.log("found!");
           active.checked = true;
-          
       }
   });
 });
 
+// Save current window tab to Chrome storage
 active.onchange = function(event) {
-  if(event.target.checked){
-    let interval = 10000;
+  if (event.target.checked) {
     
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      console.log(tabs[0]);
       let tab = tabs[0];
-      let tostore = {};
-      tostore[tab.id] = true;
-      chrome.storage.local.set(tostore);
+      let storedObj = {};
+      storedObj[tab.id] = true;
+      chrome.storage.local.set(storedObj);
     });
+
     chrome.browserAction.setBadgeText({text: 'ON'});
-    
-  }
-  else{
+
+  } else {
+
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      console.log(tabs[0]);
       let tab = tabs[0];
-      let tostore = {};
-      tostore[tab.id] = false;
-      chrome.storage.local.set(tostore);
+      let storedObj = {};
+      storedObj[tab.id] = false;
+      chrome.storage.local.set(storedObj);
     });
+
     chrome.browserAction.setBadgeText({text: 'OFF'});
+
   }
+}
+
+// Save reload interval parameter to Chrome storage
+reloadInput.onchange = function(event) {
+  const numInput = parseInt(reloadInput.value);
+  chrome.storage.local.set({ input: numInput });
 }


### PR DESCRIPTION
For Issue #3 

I added an `type="number"` input to set the reload interval (in seconds). The minimum value is 1 second but I didn't set a maximum value. If the user doesn't set a value before pressing the checkbox, it defaults to 10 seconds. I tested it in my Chrome browser on Ubuntu 20.04.1 to check if the functionality was working properly, in addition to checking if the other stuff still works.

I ended up changing around most of how the `chrome.storage.onChanged` event listener works because the way it was set up wasn't compatible with adding an extra storage value, but I couldn't find another way to implement the custom interval input without saving to `chrome.storage`. 

The other stuff are minor formatting changes and comments. I apologize in advance if it's not to your liking. 

I learned a great deal about Chrome extensions! Let me know if there's anything wrong with the code.