### PR TITLE
Added custom reload interval feature v2

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,7 +11,7 @@ chrome.storage.onChanged.addListener((whatChanged, area) => {
         if (typeof currentVal.active === 'boolean') {
             if (currentVal.active) {
                 // Start reloading current tab
-                const reloadInterval = currentVal.input ? currentVal.input * 1000 : 10000;
+                const reloadInterval = currentVal.unit === 'min' ? currentVal.input * 60 * 1000 : currentVal.input * 1000;
 
                 reloads_holder[currentKey] = setInterval(() => {
                     chrome.tabs.reload(parseInt(currentKey));

--- a/background.js
+++ b/background.js
@@ -2,6 +2,9 @@ chrome.browserAction.setBadgeText({text: 'OFF'});
 chrome.browserAction.setBadgeBackgroundColor({color: '#4688F1'});
 let reloads_holder = {};
 
+const ON = 'ON';
+const OFF = 'OFF';
+
 // Main auto-reload function
 chrome.storage.onChanged.addListener((whatChanged, area) => {
     if(area === "local") {
@@ -31,9 +34,9 @@ chrome.tabs.onActivated.addListener(()=>{
 
         chrome.storage.local.get(tab.id.toString(), (items) => {
             if (items[tab.id] && items[tab.id].active) {
-                chrome.browserAction.setBadgeText({ text: 'ON' });
+                chrome.browserAction.setBadgeText({ text: ON });
             } else {
-                chrome.browserAction.setBadgeText({ text: 'OFF' });
+                chrome.browserAction.setBadgeText({ text: OFF });
             }
         });
       });

--- a/background.js
+++ b/background.js
@@ -2,31 +2,35 @@ chrome.browserAction.setBadgeText({text: 'OFF'});
 chrome.browserAction.setBadgeBackgroundColor({color: '#4688F1'});
 let reloads_holder = {};
 
-chrome.storage.onChanged.addListener((whatchanged, area) => {
-    const currentKey = Object.keys(whatchanged)[0];
-    const currentVal = whatchanged[currentKey].newValue;
-    if(area === "local" && typeof currentVal === 'boolean' ) {
-        chrome.storage.local.get('input', (result) => {
-            if (currentVal) {
-                // Start reloading current tab
-                const reloadInterval = result.input ? result.input * 1000 : 10000;
+// Main auto-reload function
+chrome.storage.onChanged.addListener((whatChanged, area) => {
+    if(area === "local") {
+        const currentKey = Object.keys(whatChanged)[0];
+        const currentVal = whatChanged[currentKey].newValue;
 
-                reloads_holder[currentKey] = setInterval(()=>{
+        if (typeof currentVal.active === 'boolean') {
+            if (currentVal.active) {
+                // Start reloading current tab
+                const reloadInterval = currentVal.input ? currentVal.input * 1000 : 10000;
+
+                reloads_holder[currentKey] = setInterval(() => {
                     chrome.tabs.reload(parseInt(currentKey));
                 }, reloadInterval);
             } else {
                 // Stop reloading
                 clearInterval(reloads_holder[currentKey]);
             }
-        });
+        }
     }
 });
 
+// Update badge text
 chrome.tabs.onActivated.addListener(()=>{
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
         let tab = tabs[0];
+
         chrome.storage.local.get(tab.id.toString(), (items) => {
-            if (items[tab.id]) {
+            if (items[tab.id] && items[tab.id].active) {
                 chrome.browserAction.setBadgeText({ text: 'ON' });
             } else {
                 chrome.browserAction.setBadgeText({ text: 'OFF' });

--- a/background.js
+++ b/background.js
@@ -3,21 +3,20 @@ chrome.browserAction.setBadgeBackgroundColor({color: '#4688F1'});
 let reloads_holder = {};
 
 chrome.storage.onChanged.addListener((whatchanged, area) => {
-    if(area==="local"){
-        let keys = Object.keys(whatchanged);
-        keys.forEach(element => {
-            console.log(whatchanged[element]);
-            if(whatchanged[element].newValue){
-                reloads_holder[element] = setInterval(()=>{
-                    chrome.tabs.reload(parseInt(element));
-                }, 10000);
-            }
-            else {
-                clearInterval(reloads_holder[element]);
+    const currentKey = Object.keys(whatchanged)[0];
+    const currentVal = whatchanged[currentKey].newValue;
+    if(area === "local" && typeof currentVal === 'boolean' ) {
+        chrome.storage.local.get('input', (result) => {
+            if (currentVal) {
+                // Start reloading current tab
+                reloads_holder[currentKey] = setInterval(()=>{
+                    chrome.tabs.reload(parseInt(currentKey));
+                }, result.input * 1000);
+            } else {
+                // Stop reloading
+                clearInterval(reloads_holder[currentKey]);
             }
         });
-
-        
     }
 });
 
@@ -25,11 +24,10 @@ chrome.tabs.onActivated.addListener(()=>{
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
         let tab = tabs[0];
         chrome.storage.local.get(tab.id.toString(), (items) => {
-            if(items[tab.id]){
-                chrome.browserAction.setBadgeText({text: 'ON'});
-            }
-            else {
-                chrome.browserAction.setBadgeText({text: 'OFF'});
+            if (items[tab.id]) {
+                chrome.browserAction.setBadgeText({ text: 'ON' });
+            } else {
+                chrome.browserAction.setBadgeText({ text: 'OFF' });
             }
         });
       });

--- a/background.js
+++ b/background.js
@@ -9,9 +9,11 @@ chrome.storage.onChanged.addListener((whatchanged, area) => {
         chrome.storage.local.get('input', (result) => {
             if (currentVal) {
                 // Start reloading current tab
+                const reloadInterval = result.input ? result.input * 1000 : 10000;
+
                 reloads_holder[currentKey] = setInterval(()=>{
                     chrome.tabs.reload(parseInt(currentKey));
-                }, result.input * 1000);
+                }, reloadInterval);
             } else {
                 // Stop reloading
                 clearInterval(reloads_holder[currentKey]);

--- a/popup.css
+++ b/popup.css
@@ -28,11 +28,6 @@
   margin-top: 1em;
 }
 
-/* Prevent interaction with settings while running */
-.disabled {
-  pointer-events: none;
-}
-
 /* Unit Switch Button */
 
 .unit-switch {
@@ -139,3 +134,15 @@ input:checked + .toggle:before {
   font-size: 1.5em;
 }
 
+/* Prevent interaction with settings while running */
+.disabled {
+  pointer-events: none;
+}
+
+.disabled input {
+  opacity: 50%;
+}
+
+.disabled .unit-switch {
+  opacity: 50%;
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,141 @@
+/* General */
+#main-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: 'Roboto', sans-serif;
+}
+
+#num-display {
+  text-align: center;
+  font-size: 1.2em;
+}
+
+#num-display p {
+  font-size: 1.5em;
+}
+
+#settings-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1em;
+  border: 1px solid #d3d3d3;
+  user-select: none;
+}
+
+#on-switch-container {
+  margin-top: 1em;
+}
+
+/* Prevent interaction with settings while running */
+.disabled {
+  pointer-events: none;
+}
+
+/* Unit Switch Button */
+
+.unit-switch {
+  display: flex;
+  overflow: hidden;
+  margin: 1em 0 1em 0;
+}
+
+.unit-switch input {
+	position: absolute !important;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	width: 1px;
+  border: 0;
+}
+
+.unit-switch label {
+	background-color: #ffffff;
+	color: rgba(0, 0, 0, 0.6);
+  font-size: 1em;
+	text-align: center;
+	padding: 8px 16px;
+	border: 1px solid rgba(0, 0, 0, 0.2);
+  transition: all 0.1s ease-in-out;
+  
+}
+
+.unit-switch input:checked + label {
+  background-color: #2196F3;
+  color: white;
+	box-shadow: none;
+}
+
+.unit-switch label:first-of-type {
+	border-radius: 4px 0 0 4px;
+}
+
+.unit-switch label:last-of-type {
+	border-radius: 0 4px 4px 0;
+}
+
+/* On/Off Switch */
+
+.on-switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+.on-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 35px;
+}
+
+.toggle:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .toggle {
+  background-color: #2196F3;
+}
+
+input:focus + .toggle {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .toggle:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+#on-switch-container {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+#on-switch-label {
+  margin-left: 1em;
+  font-size: 1.5em;
+}
+

--- a/popup.html
+++ b/popup.html
@@ -1,14 +1,35 @@
  <!DOCTYPE html>
   <html>
     <head>
-      <style>
-      </style>
+      <link rel="stylesheet" href="popup.css">
+      <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     </head>
     <body>
-      <label for="reload-int-input">Refresh interval (seconds)</label>
-      <input type="number" min='1' id="reload-int-input" />
-      <input type="checkbox" id="active"/> 
-      <label for="active">Activate Auto-reload</label>
+      <div id="main-container">
+        <div id="settings-container">
+          <div id="num-display">
+            <label for="reload-int-display">Refresh interval</label>
+            <p id="reload-int-display">10</p>
+          </div>
+    
+          <input type="range" min="1" max="60" value="10" id="reload-int-input" />
+    
+          <div class="unit-switch">
+            <input type="radio" value="sec" id="sec" name="unit" checked >
+            <label for="sec">Seconds</label>
+            <input type="radio" value="min" id="min" name="unit" >
+            <label for="min">Minutes</label>
+          </div>
+        </div>
+
+        <div id="on-switch-container">
+          <label class="on-switch">
+            <input type="checkbox" id="active"/> 
+            <span class="toggle"></span>
+          </label>
+          <label id="on-switch-label" for="active">OFF</label>
+        </div>
+      </div>
       <script src="popup.js"></script>
     </body>
   </html>

--- a/popup.html
+++ b/popup.html
@@ -7,7 +7,8 @@
     <body>
       <label for="reload-int-input">Refresh interval (seconds)</label>
       <input type="number" min='1' id="reload-int-input" />
-      <input type="checkbox" id="active"/> Activate Auto-reload
+      <input type="checkbox" id="active"/> 
+      <label for="active">Activate Auto-reload</label>
       <script src="popup.js"></script>
     </body>
   </html>

--- a/popup.html
+++ b/popup.html
@@ -5,7 +5,9 @@
       </style>
     </head>
     <body>
-      <input type="checkbox" id="active"/> Activate timer
+      <label for="reload-int-input">Refresh interval (seconds)</label>
+      <input type="number" min='1' id="reload-int-input" />
+      <input type="checkbox" id="active"/> Activate Auto-reload
       <script src="popup.js"></script>
     </body>
   </html>

--- a/popup.js
+++ b/popup.js
@@ -1,13 +1,27 @@
 const active = document.getElementById('active');
-const reloadInput = document.getElementById('reload-int-input');
+const activeLabel = document.getElementById('on-switch-label');
+const intervalSlider = document.getElementById('reload-int-input');
+const intervalDisplay = document.getElementById('reload-int-display');
+const settingsContainer = document.getElementById('settings-container');
+const seconds = document.getElementById('sec');
+const minutes = document.getElementById('min');
 
 // Maintain checked input box if this window has active reload
 chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
   let tab = tabs[0];
   chrome.storage.local.get(tab.id.toString(), (items) => {
-    // Load reload interval if previously inputted. Otherwise, default value is 10 seconds
+    // Load previous user input settings
     if (items[tab.id]) {
-      reloadInput.value = items[tab.id].input ? items[tab.id].input : 10;
+      // Load unit check box
+      if (items[tab.id].unit === 'min') {
+        minutes.checked = true;
+      } else {
+        seconds.checked = true;
+      }
+
+      // Load Interval display
+      intervalDisplay.innerHTML = items[tab.id].input;
+      intervalSlider.value = items[tab.id].input;
     }
 
     // Check off checkbox if currently reloading
@@ -20,33 +34,48 @@ chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
 // Save current window tab to Chrome storage
 active.onchange = function(event) {
   // Save reload interval parameter to Chrome storage
-  const numInput = parseInt(reloadInput.value);
+  let numInput = parseInt(intervalSlider.value);
+  // Toggle to minutes if the option was selected
+  let unitInput = minutes.checked ? 'min' : 'sec';
 
+  // Turn ON
   if (event.target.checked) {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       let tab = tabs[0];
       let storedObj = {};
       storedObj[tab.id] = {
         active: true,
-        input: numInput
+        input: numInput,
+        unit: unitInput
       };
       chrome.storage.local.set(storedObj);
     });
 
+    activeLabel.innerHTML = 'ON';
+    settingsContainer.classList.add('disabled');
     chrome.browserAction.setBadgeText({text: 'ON'});
 
+  // Turn OFF
   } else {
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       let tab = tabs[0];
       let storedObj = {};
       storedObj[tab.id] = {
         active: false,
-        input: numInput
+        input: numInput,
+        unit: unitInput
       };
       chrome.storage.local.set(storedObj);
     });
 
+    activeLabel.innerHTML = 'OFF';
+    settingsContainer.classList.remove('disabled');
     chrome.browserAction.setBadgeText({text: 'OFF'});
 
   }
+}
+
+// Update interval display
+intervalSlider.oninput = function() {
+  intervalDisplay.innerHTML = intervalSlider.value;
 }

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,4 @@
+// Relevant DOM elements
 const active = document.getElementById('active');
 const activeLabel = document.getElementById('on-switch-label');
 const intervalSlider = document.getElementById('reload-int-input');
@@ -5,6 +6,10 @@ const intervalDisplay = document.getElementById('reload-int-display');
 const settingsContainer = document.getElementById('settings-container');
 const seconds = document.getElementById('sec');
 const minutes = document.getElementById('min');
+
+// String that displays on/off state
+const ON = 'ON';
+const OFF = 'OFF';
 
 // Maintain checked input box if this window has active reload
 chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
@@ -27,7 +32,8 @@ chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
     // Check off checkbox if currently reloading
     if(items[tab.id] && items[tab.id].active){
         active.checked = true;
-        activeLabel.innerHTML = 'ON';
+        activeLabel.innerHTML = ON;
+        settingsContainer.classList.add('disabled');
     }
   });
 });
@@ -52,9 +58,9 @@ active.onchange = function(event) {
       chrome.storage.local.set(storedObj);
     });
 
-    activeLabel.innerHTML = 'ON';
+    activeLabel.innerHTML = ON;
     settingsContainer.classList.add('disabled');
-    chrome.browserAction.setBadgeText({text: 'ON'});
+    chrome.browserAction.setBadgeText({text: ON});
 
   // Turn OFF
   } else {
@@ -69,9 +75,9 @@ active.onchange = function(event) {
       chrome.storage.local.set(storedObj);
     });
 
-    activeLabel.innerHTML = 'OFF';
+    activeLabel.innerHTML = OFF;
     settingsContainer.classList.remove('disabled');
-    chrome.browserAction.setBadgeText({text: 'OFF'});
+    chrome.browserAction.setBadgeText({text: OFF});
 
   }
 }

--- a/popup.js
+++ b/popup.js
@@ -27,6 +27,7 @@ chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
     // Check off checkbox if currently reloading
     if(items[tab.id] && items[tab.id].active){
         active.checked = true;
+        activeLabel.innerHTML = 'ON';
     }
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -1,38 +1,46 @@
 let active = document.getElementById('active');
+const reloadInput = document.getElementById('reload-int-input');
 
+// Maintain checked input box if this window has active reload
 chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
   let tab = tabs[0];
   chrome.storage.local.get(tab.id.toString(), (items) => {
       if(items[tab.id]){
           console.log("found!");
           active.checked = true;
-          
       }
   });
 });
 
+// Save current window tab to Chrome storage
 active.onchange = function(event) {
-  if(event.target.checked){
-    let interval = 10000;
+  if (event.target.checked) {
     
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      console.log(tabs[0]);
       let tab = tabs[0];
-      let tostore = {};
-      tostore[tab.id] = true;
-      chrome.storage.local.set(tostore);
+      let storedObj = {};
+      storedObj[tab.id] = true;
+      chrome.storage.local.set(storedObj);
     });
+
     chrome.browserAction.setBadgeText({text: 'ON'});
-    
-  }
-  else{
+
+  } else {
+
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-      console.log(tabs[0]);
       let tab = tabs[0];
-      let tostore = {};
-      tostore[tab.id] = false;
-      chrome.storage.local.set(tostore);
+      let storedObj = {};
+      storedObj[tab.id] = false;
+      chrome.storage.local.set(storedObj);
     });
+
     chrome.browserAction.setBadgeText({text: 'OFF'});
+
   }
+}
+
+// Save reload interval parameter to Chrome storage
+reloadInput.onchange = function(event) {
+  const numInput = parseInt(reloadInput.value);
+  chrome.storage.local.set({ input: numInput });
 }

--- a/popup.js
+++ b/popup.js
@@ -1,46 +1,52 @@
-let active = document.getElementById('active');
+const active = document.getElementById('active');
 const reloadInput = document.getElementById('reload-int-input');
 
 // Maintain checked input box if this window has active reload
 chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
   let tab = tabs[0];
   chrome.storage.local.get(tab.id.toString(), (items) => {
-      if(items[tab.id]){
-          console.log("found!");
-          active.checked = true;
-      }
+    // Load reload interval if previously inputted. Otherwise, default value is 10 seconds
+    if (items[tab.id]) {
+      reloadInput.value = items[tab.id].input ? items[tab.id].input : 10;
+    }
+
+    // Check off checkbox if currently reloading
+    if(items[tab.id] && items[tab.id].active){
+        active.checked = true;
+    }
   });
 });
 
 // Save current window tab to Chrome storage
 active.onchange = function(event) {
+  // Save reload interval parameter to Chrome storage
+  const numInput = parseInt(reloadInput.value);
+
   if (event.target.checked) {
-    
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       let tab = tabs[0];
       let storedObj = {};
-      storedObj[tab.id] = true;
+      storedObj[tab.id] = {
+        active: true,
+        input: numInput
+      };
       chrome.storage.local.set(storedObj);
     });
 
     chrome.browserAction.setBadgeText({text: 'ON'});
 
   } else {
-
     chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
       let tab = tabs[0];
       let storedObj = {};
-      storedObj[tab.id] = false;
+      storedObj[tab.id] = {
+        active: false,
+        input: numInput
+      };
       chrome.storage.local.set(storedObj);
     });
 
     chrome.browserAction.setBadgeText({text: 'OFF'});
 
   }
-}
-
-// Save reload interval parameter to Chrome storage
-reloadInput.onchange = function(event) {
-  const numInput = parseInt(reloadInput.value);
-  chrome.storage.local.set({ input: numInput });
 }


### PR DESCRIPTION
For Issue #3

I made the requested changes but I made a new PR because I couldn't figure out how to change the branch the commits are coming from in the PR edit. One major change I made was removing the `chrome.storage.local.get()` in `background.js` because once I combined `input` and `active` into one object corresponding to the `tab.id`, everything we need is already fetched by the `storage.onChanged` event listener. So everything just uses the `whatChanged[tab.id].newValue`, which is more in line with your initial implementation.

I addressed your comments in the [first PR](https://github.com/sushrut111/chrome-tab-reloader/pull/5).

I tested the functionality on 5 different tabs and it looks to be working fine on my end. Please let me know if there's anything else that needs to be fixed.